### PR TITLE
Fixed repeatable transfer appearance

### DIFF
--- a/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/BasicTransactionProvider.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/BasicTransactionProvider.java
@@ -164,10 +164,7 @@ public class BasicTransactionProvider implements TransactionProvider {
     if (transactionVerdict == null) {
       return false;
     }
-    final Verdict status = transactionVerdict.getStatus();
-    return Verdict.VALIDATED.equals(status) ||
-        Verdict.REJECTED.equals(status) ||
-        Verdict.FAILED.equals(status);
+    return Verdict.checkIfVerdictIsTerminate(transactionVerdict.getStatus());
   }
 
   private void processRejectedTransactions(Scheduler scheduler) {

--- a/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/BasicTransactionProvider.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/BasicTransactionProvider.java
@@ -115,7 +115,7 @@ public class BasicTransactionProvider implements TransactionProvider {
           .forEach(transactionBatch -> {
                 // if only BRVS signatory remains
                 if (isBatchSignedByUsers(transactionBatch, accounts)) {
-                  if (saveMissingInStorage(transactionBatch)) {
+                  if (savedMissingInStorage(transactionBatch)) {
                     cacheProvider.put(transactionBatch);
                   }
                 }
@@ -148,7 +148,7 @@ public class BasicTransactionProvider implements TransactionProvider {
     return signatoriesToPresent;
   }
 
-  private boolean saveMissingInStorage(TransactionBatch transactionBatch) {
+  private boolean savedMissingInStorage(TransactionBatch transactionBatch) {
     return transactionBatch
         .stream()
         .map(ValidationUtils::hexHash)

--- a/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/util/CacheProvider.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/provider/impl/util/CacheProvider.java
@@ -14,7 +14,6 @@ import iroha.protocol.Commands.Command;
 import iroha.protocol.Commands.TransferAsset;
 import iroha.protocol.TransactionOuterClass.Transaction;
 import iroha.validation.transactions.TransactionBatch;
-import iroha.validation.utils.ValidationUtils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -90,8 +89,10 @@ public class CacheProvider {
               .forEach(transferAsset -> {
                 final String srcAccountId = transferAsset.getSrcAccountId();
                 final String hash = hexHash(transaction);
-                logger.info("Locked {} account by transfer hash {}", srcAccountId, hash);
-                pendingAccounts.put(srcAccountId, hash);
+                if (!pendingAccounts.containsKey(srcAccountId)) {
+                  logger.info("Locked {} account by transfer hash {}", srcAccountId, hash);
+                  pendingAccounts.put(srcAccountId, hash);
+                }
               })
       );
       logger.info("Publishing {} transactions for validation", hexHash(transactionBatch));

--- a/brvs-core/src/main/java/iroha/validation/transactions/storage/impl/dummy/DummyMemoryTransactionVerdictStorage.java
+++ b/brvs-core/src/main/java/iroha/validation/transactions/storage/impl/dummy/DummyMemoryTransactionVerdictStorage.java
@@ -9,12 +9,12 @@ import io.reactivex.Observable;
 import io.reactivex.subjects.PublishSubject;
 import iroha.validation.transactions.storage.TransactionVerdictStorage;
 import iroha.validation.verdict.ValidationResult;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class DummyMemoryTransactionVerdictStorage implements TransactionVerdictStorage {
 
-  private final Map<String, ValidationResult> validationResultMap = new HashMap<>();
+  private final Map<String, ValidationResult> validationResultMap = new ConcurrentHashMap<>();
   private final PublishSubject<String> subject = PublishSubject.create();
 
   /**
@@ -30,7 +30,7 @@ public class DummyMemoryTransactionVerdictStorage implements TransactionVerdictS
    */
   @Override
   public boolean markTransactionPending(String txHash) {
-    validationResultMap.put(txHash.toUpperCase(), ValidationResult.PENDING);
+    validationResultMap.putIfAbsent(txHash.toUpperCase(), ValidationResult.PENDING);
     return true;
   }
 

--- a/brvs-rules/src/main/java/iroha/validation/verdict/Verdict.java
+++ b/brvs-rules/src/main/java/iroha/validation/verdict/Verdict.java
@@ -5,10 +5,23 @@
 
 package iroha.validation.verdict;
 
+import java.util.Arrays;
+import java.util.Collection;
+
 public enum Verdict {
   UNKNOWN,
   PENDING,
   VALIDATED,
   REJECTED,
-  FAILED
+  FAILED;
+
+  private static Collection<Verdict> terminateVerdicts = Arrays.asList(
+      VALIDATED,
+      REJECTED,
+      FAILED
+  );
+
+  public static boolean checkIfVerdictIsTerminate(Verdict verdict) {
+    return terminateVerdicts.contains(verdict);
+  }
 }


### PR DESCRIPTION
Previously it could be possible to add a transaction to the cache once again in a time between signing and Iroha requerying.