### PR TITLE
[DOPS-985] Move sora-net docker images to the new registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
             }
             steps {
                 script {
-                    withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
+                    withCredentials([usernamePassword(credentialsId: 'bot-soranet-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
                         env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                         env.TAG = env.TAG_NAME ? env.TAG_NAME : dockerTags[env.GIT_BRANCH]
                         sh "./gradlew dockerPush"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,7 @@ pipeline {
             steps {
                 script {
                     withCredentials([usernamePassword(credentialsId: 'nexus-soramitsu-rw', usernameVariable: 'DOCKER_REGISTRY_USERNAME', passwordVariable: 'DOCKER_REGISTRY_PASSWORD')]) {
-                        env.DOCKER_REGISTRY_URL = "https://nexus.iroha.tech:19004"
+                        env.DOCKER_REGISTRY_URL = "https://docker.soramitsu.co.jp"
                         env.TAG = env.TAG_NAME ? env.TAG_NAME : dockerTags[env.GIT_BRANCH]
                         sh "./gradlew dockerPush"
                     }


### PR DESCRIPTION
# Task

[DOPS-985]: Move sora-net docker images to the new registry.

## Changes

1. Harbor registry used.

## Author

Signed-off-by: Dmitriy Creed <creed@soramitsu.co.jp>

[DOPS-985]: https://soramitsu.atlassian.net/browse/DOPS-985